### PR TITLE
Prevent caching

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,10 @@ import { DOWNLOAD_LINK, VERSION } from "./constants";
 	if (!gs) throw new Error("The game status request failed.");
 
 	app.use(cors());
+	app.use((req, res, next) => {
+		res.set('Cache-Control', 'no-store')
+		next()
+	})
 
 	app.get(/\/(api\/)?game.min.js/, async (req, res) => {
 		if (req.query.version && typeof req.query.version !== "string")


### PR DESCRIPTION
On some devices the modified game.min.js might be caching. Which might cause some problems.

In express you can specify not to cache using this:
```js
app.use((req, res, next) => {
  res.set('Cache-Control', 'no-store')
  next()
})
```